### PR TITLE
Change port to 3334

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,4 +1,7 @@
 ## node-kiba changelog
 
+### [ [>](https://github.com/AtomicLoans/node-kiba/tree/v1.0.1) ] 1.0.1 / 27.04.2020
+* Change websocket port to 3334
+
 ### [ [>](https://github.com/AtomicLoans/node-kiba/tree/v1.0.0) ] 1.0.0 / 27.04.2020
 * Initial release

--- a/KibaConnector.js
+++ b/KibaConnector.js
@@ -4,7 +4,7 @@ const express = require('express');
 
 const RemoteKibaProvider = require('./RemoteKibaProvider');
 
-const DEFAULT_PORT = 3333;
+const DEFAULT_PORT = 3334;
 
 class KibaConnector {
   constructor(options) {

--- a/README.md
+++ b/README.md
@@ -18,12 +18,12 @@ yarn add node-kiba
 
 const KibaConnector = require('node-kiba');
 const connector = new KibaConnector({
-  port: 3333, // this is the default port
+  port: 3334, // this is the default port
   onConnect() { console.log('Kiba client connected') }, // Function to run when Kiba is connected (optional)
 });
 
 connector.start().then(() => {
-  // Now go to http://localhost:3333 in your Kiba enabled web browser.
+  // Now go to http://localhost:3334 in your Kiba enabled web browser.
   const uniweb3 = connector.getProvider()
   // Use uniweb3 as you would normally do. Sign transactions in the browser.
 });

--- a/client/index.js
+++ b/client/index.js
@@ -58,7 +58,7 @@ function sleep(ms) {
   if (!(await checkUnlocked())) {
     return addLog('Please unlock Kiba first and then reload this page');
   }
-  const socket = new WebSocket('ws://localhost:3333');
+  const socket = new WebSocket('ws://localhost:3334');
   const reply = (action, requestId, payload) => socket.send(JSON.stringify({ action, requestId, payload }));
   socket.onmessage = msg => {
     let message;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-kiba",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Connect to Kiba from node.js",
   "author": "Mattthew Black <matthew@atomicloans.io>",
   "license": "MIT",


### PR DESCRIPTION
### Description

This PR changes the default port used for the websocket in Node Kiba to 3334 in order not to interfere with https://github.com/JoinColony/node-metamask

### Submission Checklist :pencil:

- [x] Change default websockets port to 3334
- [x] Bump to 1.0.1
 